### PR TITLE
add host attribute for current condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-angular-query-builder",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/ngx-angular-query-builder/src/lib/query-builder/query-builder.component.ts
+++ b/projects/ngx-angular-query-builder/src/lib/query-builder/query-builder.component.ts
@@ -47,7 +47,8 @@ import {
   SimpleChanges,
   TemplateRef,
   ViewChild,
-  ElementRef
+  ElementRef,
+  HostBinding
 } from '@angular/core';
 
 export const CONTROL_VALUE_ACCESSOR: any = {
@@ -113,6 +114,11 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   };
   @Input() disabled = false;
   @Input() data: RuleSet = { condition: 'add', rules: [] };
+
+
+  @HostBinding('attr.query-builder-condition') get condintion() {
+    return this.data?.condition;
+  }
 
   // For ControlValueAccessor interface
   public onChangeCallback!: () => void;


### PR DESCRIPTION
Applies the attribute `query-builder-condition="[condition]"` the `query-builder` component based upon the current condition of the ruleset. Useful for applying styles based upon the currently selection condition for a ruleset. 