### PR TITLE
Removed parentValue's initial value

### DIFF
--- a/projects/ngx-angular-query-builder/src/lib/query-builder/query-builder.component.ts
+++ b/projects/ngx-angular-query-builder/src/lib/query-builder/query-builder.component.ts
@@ -129,7 +129,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
   @Input() emptyMessage = 'A ruleset cannot be empty. Please add a rule or remove it all together.';
   @Input() classNames: QueryBuilderClassNames = {};
   @Input() operatorMap: { [key: string]: string[] } = {};
-  @Input() parentValue: RuleSet = { condition: 'and', rules: [] };
+  @Input() parentValue?: RuleSet;
   @Input() config: QueryBuilderConfig = { fields: {} };
   @Input() parentArrowIconTemplate!: QueryArrowIconDirective;
   @Input() parentInputTemplates!: QueryList<QueryInputDirective>;
@@ -460,7 +460,7 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     parent = parent || this.parentValue;
     if (this.config.removeRuleSet) {
       this.config.removeRuleSet(ruleset, parent);
-    } else {
+    } else if (parent) {
       parent.rules = parent.rules.filter((r) => r !== ruleset);
     }
 

--- a/projects/ngx-angular-query-builder/src/lib/query-builder/query-builder.interfaces.ts
+++ b/projects/ngx-angular-query-builder/src/lib/query-builder/query-builder.interfaces.ts
@@ -95,7 +95,7 @@ export interface QueryBuilderConfig {
   getOptions?: (field: string) => Option[];
   addRuleSet?: (parent: RuleSet) => void;
   addRule?: (parent: RuleSet) => void;
-  removeRuleSet?: (ruleset: RuleSet, parent: RuleSet) => void;
+  removeRuleSet?: (ruleset: RuleSet, parent?: RuleSet) => void;
   removeRule?: (rule: Rule, parent: RuleSet) => void;
   coerceValueForOperator?: (operator: string, value: any, rule: Rule) => any;
   calculateFieldChangeValue?: (currentField: Field,


### PR DESCRIPTION
When the parentValue has an initial value, the first 'RuleSet' has a remove button that doesn't function.
I removed the default more closely match the original version here: https://github.com/zebzhao/Angular-QueryBuilder/blob/master/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.ts#L126